### PR TITLE
Add a Travis CI config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+---
+sudo: false
+addons:
+  apt:
+    packages:
+      - aspell
+      - aspell-en
+language: perl
+perl:
+  - blead
+  - dev
+  - '5.28'
+  - '5.26'
+  - '5.24'
+  - '5.22'
+  - '5.20'
+  - '5.18'
+  - '5.16'
+  - '5.14'
+cache:
+  directories:
+    - $HOME/perl5
+matrix:
+  allow_failures:
+    - perl: blead
+  fast_finish: 1
+  include:
+    - env: COVERAGE=1
+      perl: '5.28'
+env:
+  global:
+    - AUTHOR_TESTING=1
+    - RELEASE_TESTING=1
+before_install:
+  - eval $(curl https://travis-perl.github.io/init) --auto --always-upgrade-modules
+### __app_cisetup__
+# ---
+# force_threaded_perls: 0
+# perl_caching: 1
+
+### __app_cisetup__


### PR DESCRIPTION
I generated the file using https://metacpan.org/release/App-CISetup

Passing build results are at https://travis-ci.org/oalders/moosex-workers/builds/466597535

You'd just need to flip the switch at https://travis-ci.org/account/repositories to enable builds on this upstream repository. This was done as part of the last month of the CPAN Pull Request Challenge (CPC).